### PR TITLE
Added support for 6 database engines

### DIFF
--- a/src/main/java/org/stdg/dbtype/BasePrimaryKeyColumnsFinder.java
+++ b/src/main/java/org/stdg/dbtype/BasePrimaryKeyColumnsFinder.java
@@ -25,7 +25,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-public class BasePrimaryKeyColumnsFinder implements PrimaryKeyColumnsFinder {
+class BasePrimaryKeyColumnsFinder implements PrimaryKeyColumnsFinder {
 
     private final DataSource dataSource;
 

--- a/src/main/java/org/stdg/dbtype/DatabaseMetadataFinderFactory.java
+++ b/src/main/java/org/stdg/dbtype/DatabaseMetadataFinderFactory.java
@@ -46,6 +46,11 @@ public class DatabaseMetadataFinderFactory {
             return new PostgreSqlMetadataFinder(dataSource);
         }
 
+        if (dbType.equals(MARIA_DB) || dbType.equals(MY_SQL)
+        ) {
+            return new MariaDBMySQLMetadataFinder(dataSource);
+        }
+
         return new DefaultDatabaseMetadataFinder(dataSource);
 
     }

--- a/src/main/java/org/stdg/dbtype/DatabaseMetadataFinderFactory.java
+++ b/src/main/java/org/stdg/dbtype/DatabaseMetadataFinderFactory.java
@@ -42,6 +42,10 @@ public class DatabaseMetadataFinderFactory {
             return new HsqlDbMetadataFinder(dataSource);
         }
 
+        if(dbType.equals(POSTGRE_SQL)) {
+            return new PostgreSqlMetadataFinder(dataSource);
+        }
+
         return new DefaultDatabaseMetadataFinder(dataSource);
 
     }

--- a/src/main/java/org/stdg/dbtype/DatabaseMetadataFinderFactory.java
+++ b/src/main/java/org/stdg/dbtype/DatabaseMetadataFinderFactory.java
@@ -46,9 +46,12 @@ public class DatabaseMetadataFinderFactory {
             return new PostgreSqlMetadataFinder(dataSource);
         }
 
-        if (dbType.equals(MARIA_DB) || dbType.equals(MY_SQL)
-        ) {
+        if (dbType.equals(MARIA_DB) || dbType.equals(MY_SQL)) {
             return new MariaDBMySQLMetadataFinder(dataSource);
+        }
+
+        if(dbType.equals(MICROSOFT_SQL_SERVER)) {
+            return new MSSQLServerMetadataFinder(dataSource);
         }
 
         return new DefaultDatabaseMetadataFinder(dataSource);

--- a/src/main/java/org/stdg/dbtype/DatabaseMetadataFinderFactory.java
+++ b/src/main/java/org/stdg/dbtype/DatabaseMetadataFinderFactory.java
@@ -38,6 +38,10 @@ public class DatabaseMetadataFinderFactory {
             return new H2MetadataFinder(dataSource);
         }
 
+        if(dbType.equals(HSQLDB)) {
+            return new HsqlDbMetadataFinder(dataSource);
+        }
+
         return new DefaultDatabaseMetadataFinder(dataSource);
 
     }

--- a/src/main/java/org/stdg/dbtype/DatabaseMetadataFinderFactory.java
+++ b/src/main/java/org/stdg/dbtype/DatabaseMetadataFinderFactory.java
@@ -17,6 +17,8 @@ import org.stdg.DatabaseMetadataFinder;
 
 import javax.sql.DataSource;
 
+import static org.stdg.dbtype.DatabaseType.*;
+
 /**
  * Factory to create an instance of {@link org.stdg.DatabaseMetadataFinder}.
  */
@@ -31,6 +33,10 @@ public class DatabaseMetadataFinderFactory {
      * @return An instance of DatabaseMetadataFinder
      */
     public static DatabaseMetadataFinder createFrom(DataSource dataSource, DatabaseType dbType) {
+
+        if(dbType.equals(H2)) {
+            return new H2MetadataFinder(dataSource);
+        }
 
         return new DefaultDatabaseMetadataFinder(dataSource);
 

--- a/src/main/java/org/stdg/dbtype/DefaultColumnOrdersFinder.java
+++ b/src/main/java/org/stdg/dbtype/DefaultColumnOrdersFinder.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2021-2021 the original author or authors.
+ */
+
+package org.stdg.dbtype;
+
+import org.stdg.ColumnOrdersFinder;
+import org.stdg.PreparedStatementBuilder;
+import org.stdg.SqlQuery;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class DefaultColumnOrdersFinder implements ColumnOrdersFinder {
+
+    private static final SqlQuery COLUMN_ORDER_QUERY = new SqlQuery(
+            " select table_schema," +
+                    "        table_name," +
+                    "        column_name," +
+                    "        ordinal_position as position" +
+                    " from information_schema.columns" +
+                    " where table_name=?" +
+                    " order by position");
+
+    private final DataSource dataSource;
+
+    DefaultColumnOrdersFinder(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public List<String> findDatabaseColumnOrdersOf(String tableName) {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement columnOrderStatement = PreparedStatementBuilder.buildFrom(COLUMN_ORDER_QUERY, connection)) {
+            columnOrderStatement.setString(1, tableName);
+            ResultSet queryResult = columnOrderStatement.executeQuery();
+            return findColumnOrderFrom(queryResult);
+        } catch (SQLException sqlException) {
+            sqlException.printStackTrace();
+        }
+        return Collections.emptyList();
+    }
+
+    private List<String> findColumnOrderFrom(ResultSet queryResult) throws SQLException {
+        List<String> columnOrder = new ArrayList<>();
+        while (queryResult.next()) {
+            String columnName = queryResult.getString(3);
+            columnOrder.add(columnName);
+        }
+        return columnOrder;
+    }
+
+}

--- a/src/main/java/org/stdg/dbtype/DefaultPrimaryKeyColumnsFinder.java
+++ b/src/main/java/org/stdg/dbtype/DefaultPrimaryKeyColumnsFinder.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2021-2021 the original author or authors.
+ */
+
+package org.stdg.dbtype;
+
+import org.stdg.PrimaryKeyColumnsFinder;
+import org.stdg.SqlQuery;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+class DefaultPrimaryKeyColumnsFinder implements PrimaryKeyColumnsFinder {
+
+    private static final SqlQuery PRIMARY_COLUMNS_QUERY = new SqlQuery(
+            "select \n" +
+                    "     cons.table_schema,\n" +
+                    "     cons.table_name,\n" +
+                    "     cons.constraint_name,\n" +
+                    "     cols.column_name,\n" +
+                    "     cols.ordinal_position as position\n" +
+                    " from information_schema.table_constraints cons\n" +
+                    " join information_schema.key_column_usage cols on (cons.table_schema = cols.table_schema \n" +
+                    " and cons.table_name = cols.table_name\n" +
+                    " and cons.constraint_name = cols.constraint_name)\n" +
+                    " where cons.table_name = ?" + "\n" +
+                    " and cons.constraint_type='PRIMARY KEY'"
+    );
+
+    private final PrimaryKeyColumnsFinder delegate;
+
+    DefaultPrimaryKeyColumnsFinder(DataSource dataSource) {
+        delegate = new BasePrimaryKeyColumnsFinder(dataSource, PRIMARY_COLUMNS_QUERY);
+    }
+
+    @Override
+    public List<String> findPrimaryColumnsOf(String tableName) {
+        return delegate.findPrimaryColumnsOf(tableName);
+    }
+
+}

--- a/src/main/java/org/stdg/dbtype/H2MetadataFinder.java
+++ b/src/main/java/org/stdg/dbtype/H2MetadataFinder.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2021-2021 the original author or authors.
+ */
+
+package org.stdg.dbtype;
+
+import org.stdg.*;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.List;
+
+class H2MetadataFinder implements DatabaseMetadataFinder {
+
+    private static final SqlQuery H2_REFERENCED_TABLES_QUERY = new SqlQuery(
+            "with\n" +
+                    "    recursive parent_child_tree (table_name, ref_table_name, level) as\n" +
+                    "    (\n" +
+                    "    select distinct\n" +
+                    "        child.table_name     as table_name,\n" +
+                    "        parent.table_name    as ref_table_name,\n" +
+                    "        1                    as level\n" +
+                    "    from information_schema.table_constraints child\n" +
+                    "    join information_schema.referential_constraints rco\n" +
+                    "    on rco.constraint_name = child.constraint_name\n" +
+                    "    join information_schema.constraints parent\n" +
+                    "    on parent.unique_index_name = rco.unique_constraint_name\n" +
+                    "    where\n" +
+                    "        child.table_name != parent.table_name and\n" +
+                    "        child.table_name=?\n" +
+                    "    UNION ALL\n" +
+                    "    select pc.table_name, pc.ref_table_name, pct.level + 1 as level\n" +
+                    "    from\n" +
+                    "        (\n" +
+                    "        select \n" +
+                    "            child.table_name     as table_name,\n" +
+                    "            parent.table_name    as ref_table_name,\n" +
+                    "            1                    as level\n" +
+                    "        from information_schema.table_constraints child\n" +
+                    "        join information_schema.referential_constraints rco\n" +
+                    "        on rco.constraint_name = child.constraint_name\n" +
+                    "        join information_schema.constraints parent\n" +
+                    "        on parent.unique_index_name = rco.unique_constraint_name\n" +
+                    "        where\n" +
+                    "            child.table_name != parent.table_name\n" +
+                    "        ) pc\n" +
+                    "    join parent_child_tree pct on (pc.table_name = pct.ref_table_name)\n" +
+                    "    )\n" +
+                    "select distinct *\n" +
+                    "from parent_child_tree\n" +
+                    "order by level desc");
+
+    private static final SqlQuery H2_COLUMNS_MAPPINGS_QUERY = new SqlQuery(
+            "select \n" +
+                    "        fktable_schema as table_schema,\n" +
+                    "        fktable_name   as table_name,\n" +
+                    "        fkcolumn_name  as column_name,\n" +
+                    "        pktable_schema as ref_table_schema,\n" +
+                    "        pktable_name   as ref_table_name,\n" +
+                    "        pkcolumn_name  as ref_column_name\n" +
+                    "  from information_schema.cross_references \n" +
+                    "  where fktable_name = ?"
+    );
+
+    private final DefaultColumnOrdersFinder defaultColumnOrdersFinder;
+
+    private final NotNullColumnsFinder defaultNotNullColumnsFinder;
+
+    private final ReferencedTablesFinder h2ReferencedTablesFinder;
+
+    private final ColumnsMappingsFinder h2ColumnsMappingsFinder;
+
+    private final PrimaryKeyColumnsFinder primaryKeyColumnsFinder;
+
+    H2MetadataFinder(DataSource dataSource) {
+        this.defaultColumnOrdersFinder = new DefaultColumnOrdersFinder(dataSource);
+        this.defaultNotNullColumnsFinder = new DefaultNotNullColumnsFinder(dataSource);
+        this.h2ReferencedTablesFinder = new BaseReferencedTablesFinder(dataSource, H2_REFERENCED_TABLES_QUERY);
+        this.h2ColumnsMappingsFinder = new BaseColumnsMappingsFinder(dataSource, H2_COLUMNS_MAPPINGS_QUERY);
+        this.primaryKeyColumnsFinder = new DefaultPrimaryKeyColumnsFinder(dataSource);
+    }
+
+    @Override
+    public List<String> findDatabaseColumnOrdersOf(String tableName) {
+        return defaultColumnOrdersFinder.findDatabaseColumnOrdersOf(tableName);
+    }
+
+    @Override
+    public Collection<String> findNotNullColumnsOf(String tableName) {
+        return defaultNotNullColumnsFinder.findNotNullColumnsOf(tableName);
+    }
+
+    @Override
+    public ReferencedTableSet findReferencedTablesOf(String tableName) {
+        return h2ReferencedTablesFinder.findReferencedTablesOf(tableName);
+    }
+
+    @Override
+    public ColumnsMappingGroup findColumnsMappingsOf(String tableName) {
+        return h2ColumnsMappingsFinder.findColumnsMappingsOf(tableName);
+    }
+
+    @Override
+    public List<String> findPrimaryColumnsOf(String tableName) {
+        return primaryKeyColumnsFinder.findPrimaryColumnsOf(tableName);
+    }
+
+}

--- a/src/main/java/org/stdg/dbtype/HsqlDbMetadataFinder.java
+++ b/src/main/java/org/stdg/dbtype/HsqlDbMetadataFinder.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2021-2021 the original author or authors.
+ */
+
+package org.stdg.dbtype;
+
+import org.stdg.*;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.List;
+
+class HsqlDbMetadataFinder implements DatabaseMetadataFinder {
+
+    private static final SqlQuery HSQL_DB_REFERENCED_TABLES_QUERY = new SqlQuery(
+            "with\n" +
+                    "    recursive parent_child_tree (table_name, ref_table_name, level) as\n" +
+                    "    (\n" +
+                    "    select distinct\n" +
+                    "        child.table_name     as table_name,\n" +
+                    "        parent.table_name    as ref_table_name,\n" +
+                    "        1                    as level\n" +
+                    "    from information_schema.table_constraints child\n" +
+                    "    join information_schema.referential_constraints rco\n" +
+                    "          on rco.constraint_name = child.constraint_name\n" +
+                    "    join information_schema.table_constraints parent\n" +
+                    "          on parent.constraint_name = rco.unique_constraint_name\n" +
+                    "    where\n" +
+                    "        child.table_name != parent.table_name and\n" +
+                    "        child.table_name=?\n" +
+                    "    UNION\n" +
+                    "    select pc.table_name, pc.ref_table_name, pct.level + 1 as level\n" +
+                    "    from\n" +
+                    "        (\n" +
+                    "        select distinct\n" +
+                    "            child.table_name     as table_name,\n" +
+                    "            parent.table_name    as ref_table_name,\n" +
+                    "            1                    as level\n" +
+                    "        from information_schema.table_constraints child\n" +
+                    "        join information_schema.referential_constraints rco\n" +
+                    "            on rco.constraint_name = child.constraint_name\n" +
+                    "        join information_schema.table_constraints parent\n" +
+                    "            on parent.constraint_name = rco.unique_constraint_name\n" +
+                    "        where\n" +
+                    "            child.table_name != parent.table_name\n" +
+                    "        ) pc\n" +
+                    "    join parent_child_tree pct on (pc.table_name = pct.ref_table_name)\n" +
+                    "    )\n" +
+                    "select distinct *\n" +
+                    "from parent_child_tree\n" +
+                    "order by level desc");
+
+    private static final SqlQuery HSQL_DB_COLUMNS_MAPPINGS_QUERY = new SqlQuery(
+            "select\n" +
+                    "       child_constraint.table_schema    as table_schema,\n" +
+                    "       child_constraint.table_name      as table_name,\n" +
+                    "       child_cons_cols.column_name      as column_name,\n" +
+                    "       parent_cons_cols.table_schema    as ref_table_schema,\n" +
+                    "       parent_cons_cols.table_name      as ref_table_name,\n" +
+                    "       parent_cons_cols.column_name     as ref_column_name\n" +
+                    "  from information_schema.table_constraints as child_constraint\n" +
+                    "  join information_schema.key_column_usage as child_cons_cols\n" +
+                    "       on (child_constraint.constraint_schema = child_cons_cols.constraint_schema\n" +
+                    "           and\n" +
+                    "           child_constraint.constraint_name = child_cons_cols.constraint_name\n" +
+                    "           and\n" +
+                    "           child_constraint.table_schema = child_cons_cols.table_schema)\n" +
+                    "  join information_schema.referential_constraints as ref\n" +
+                    "       on (child_constraint.constraint_schema = ref.constraint_schema\n" +
+                    "           and\n" +
+                    "           child_constraint.constraint_name = ref.constraint_name)\n" +
+                    "  join information_schema.key_column_usage as parent_cons_cols\n" +
+                    "       on (parent_cons_cols.constraint_schema = ref.unique_constraint_schema\n" +
+                    "           and\n" +
+                    "           parent_cons_cols.constraint_name = ref.unique_constraint_name)\n" +
+                    "where child_constraint.constraint_type = 'FOREIGN KEY' and child_constraint.table_name=?"
+    );
+
+    private final DefaultColumnOrdersFinder defaultColumnOrdersFinder;
+
+    private final NotNullColumnsFinder defaultNotNullColumnsFinder;
+
+    private final ReferencedTablesFinder hsqlDbReferencedTablesFinder;
+
+    private final ColumnsMappingsFinder hsqlDbColumnsMappingsFinder;
+
+    private final DefaultPrimaryKeyColumnsFinder primaryKeyColumnsFinder;
+
+    HsqlDbMetadataFinder(DataSource dataSource) {
+        this.defaultColumnOrdersFinder = new DefaultColumnOrdersFinder(dataSource);
+        this.defaultNotNullColumnsFinder = new DefaultNotNullColumnsFinder(dataSource);
+        this.hsqlDbReferencedTablesFinder = new BaseReferencedTablesFinder(dataSource, HSQL_DB_REFERENCED_TABLES_QUERY);
+        this.hsqlDbColumnsMappingsFinder = new BaseColumnsMappingsFinder(dataSource, HSQL_DB_COLUMNS_MAPPINGS_QUERY);
+        this.primaryKeyColumnsFinder = new DefaultPrimaryKeyColumnsFinder(dataSource);
+    }
+
+    @Override
+    public List<String> findDatabaseColumnOrdersOf(String tableName) {
+        return defaultColumnOrdersFinder.findDatabaseColumnOrdersOf(tableName);
+    }
+
+    @Override
+    public Collection<String> findNotNullColumnsOf(String tableName) {
+        return defaultNotNullColumnsFinder.findNotNullColumnsOf(tableName);
+    }
+
+    @Override
+    public ReferencedTableSet findReferencedTablesOf(String tableName) {
+        return hsqlDbReferencedTablesFinder.findReferencedTablesOf(tableName);
+    }
+
+    @Override
+    public ColumnsMappingGroup findColumnsMappingsOf(String tableName) {
+        return hsqlDbColumnsMappingsFinder.findColumnsMappingsOf(tableName);
+    }
+
+    @Override
+    public List<String> findPrimaryColumnsOf(String tableName) {
+        return primaryKeyColumnsFinder.findPrimaryColumnsOf(tableName);
+    }
+
+}

--- a/src/main/java/org/stdg/dbtype/MSSQLServerMetadataFinder.java
+++ b/src/main/java/org/stdg/dbtype/MSSQLServerMetadataFinder.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2021-2021 the original author or authors.
+ */
+
+package org.stdg.dbtype;
+
+import org.stdg.*;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+class MSSQLServerMetadataFinder implements DatabaseMetadataFinder {
+
+    private static final SqlQuery MS_SQL_SERVER_REFERENCED_TABLES_QUERY = new SqlQuery(
+            "with\n" +
+                    "    parent_child_tree as\n" +
+                    "    (\n" +
+                    "    select distinct\n" +
+                    "           child.table_name    as table_name,\n" +
+                    "           parent.table_name   as ref_table_name,\n" +
+                    "           1 as level\n" +
+                    "    from information_schema.referential_constraints rco\n" +
+                    "    join information_schema.table_constraints child\n" +
+                    "            on rco.constraint_name = child.constraint_name\n" +
+                    "            and rco.constraint_schema = child.table_schema\n" +
+                    "    join information_schema.table_constraints parent\n" +
+                    "            on rco.unique_constraint_name = parent.constraint_name\n" +
+                    "            and rco.unique_constraint_schema = parent.table_schema\n" +
+                    "    where child.table_name != parent.table_name\n" +
+                    "        and child.table_name=?\n" +
+                    "    UNION ALL\n" +
+                    "    select pc.table_name, pc.ref_table_name, pct.level + 1 as level\n" +
+                    "    from\n" +
+                    "        (\n" +
+                    "        select \n" +
+                    "               child.table_name    as table_name,\n" +
+                    "               parent.table_name   as ref_table_name,\n" +
+                    "               1 as level\n" +
+                    "        from information_schema.referential_constraints rco\n" +
+                    "        join information_schema.table_constraints child\n" +
+                    "                on rco.constraint_name = child.constraint_name\n" +
+                    "                and rco.constraint_schema = child.table_schema\n" +
+                    "        join information_schema.table_constraints parent\n" +
+                    "                on rco.unique_constraint_name = parent.constraint_name\n" +
+                    "                and rco.unique_constraint_schema = parent.table_schema\n" +
+                    "        where child.table_name != parent.table_name\n" +
+                    "        ) pc\n" +
+                    "    join parent_child_tree pct on (pc.table_name = pct.ref_table_name)\n" +
+                    "    )\n" +
+                    "select distinct *\n" +
+                    "from parent_child_tree\n" +
+                    "order by level desc");
+
+    private static final SqlQuery MS_SQL_SERVER_COLUMNS_MAPPINGS_QUERY = new SqlQuery(
+            "select\n" +
+                    "       child_constraint.table_schema    as table_schema,\n" +
+                    "       child_constraint.table_name      as table_name,\n" +
+                    "       child_cons_cols.column_name      as column_name,\n" +
+                    "       parent_cons_cols.table_schema    as ref_table_schema,\n" +
+                    "       parent_cons_cols.table_name      as ref_table_name,\n" +
+                    "       parent_cons_cols.column_name     as ref_column_name\n" +
+                    "  from information_schema.table_constraints as child_constraint\n" +
+                    "  join information_schema.key_column_usage as child_cons_cols\n" +
+                    "       on (child_constraint.constraint_schema = child_cons_cols.constraint_schema\n" +
+                    "           and\n" +
+                    "           child_constraint.constraint_name = child_cons_cols.constraint_name\n" +
+                    "           and\n" +
+                    "           child_constraint.table_schema = child_cons_cols.table_schema)\n" +
+                    "  join information_schema.referential_constraints as ref\n" +
+                    "       on (child_constraint.constraint_schema = ref.constraint_schema\n" +
+                    "           and\n" +
+                    "           child_constraint.constraint_name = ref.constraint_name)\n" +
+                    "  join information_schema.key_column_usage as parent_cons_cols\n" +
+                    "       on (parent_cons_cols.constraint_schema = ref.unique_constraint_schema\n" +
+                    "           and\n" +
+                    "           parent_cons_cols.constraint_name = ref.unique_constraint_name)\n" +
+                    "where child_constraint.constraint_type = 'FOREIGN KEY' and child_constraint.table_name=?");
+
+    private final DefaultColumnOrdersFinder defaultColumnOrdersFinder;
+
+    private final NotNullColumnsFinder defaultNotNullColumnsFinder;
+
+    private final ReferencedTablesFinder mssqlServerReferencedTablesFinder;
+
+    private final ColumnsMappingsFinder mssqlServerColumnsMappingsFinder;
+
+    MSSQLServerMetadataFinder(DataSource dataSource) {
+        this.defaultColumnOrdersFinder = new DefaultColumnOrdersFinder(dataSource);
+        this.defaultNotNullColumnsFinder = new DefaultNotNullColumnsFinder(dataSource);
+        this.mssqlServerReferencedTablesFinder = new BaseReferencedTablesFinder(dataSource, MS_SQL_SERVER_REFERENCED_TABLES_QUERY);
+        this.mssqlServerColumnsMappingsFinder = new BaseColumnsMappingsFinder(dataSource, MS_SQL_SERVER_COLUMNS_MAPPINGS_QUERY);
+    }
+
+    @Override
+    public List<String> findDatabaseColumnOrdersOf(String tableName) {
+        return defaultColumnOrdersFinder.findDatabaseColumnOrdersOf(tableName);
+    }
+
+    @Override
+    public Collection<String> findNotNullColumnsOf(String tableName) {
+        return defaultNotNullColumnsFinder.findNotNullColumnsOf(tableName);
+    }
+
+    @Override
+    public ReferencedTableSet findReferencedTablesOf(String tableName) {
+        return mssqlServerReferencedTablesFinder.findReferencedTablesOf(tableName);
+    }
+
+    @Override
+    public ColumnsMappingGroup findColumnsMappingsOf(String tableName) {
+        return mssqlServerColumnsMappingsFinder.findColumnsMappingsOf(tableName);
+    }
+
+    @Override
+    public List<String> findPrimaryColumnsOf(String tableName) {
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/org/stdg/dbtype/MariaDBMySQLMetadataFinder.java
+++ b/src/main/java/org/stdg/dbtype/MariaDBMySQLMetadataFinder.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2021-2021 the original author or authors.
+ */
+
+package org.stdg.dbtype;
+
+import org.stdg.*;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+class MariaDBMySQLMetadataFinder implements DatabaseMetadataFinder {
+
+    private static final SqlQuery MARIA_DB_MY_SQL_COLUMNS_MAPPINGS_QUERY
+            = new SqlQuery("select\n" +
+            "       child_constraint.table_schema            as table_schema,\n" +
+            "       child_constraint.table_name              as table_name,\n" +
+            "       child_cons_cols.column_name              as column_name,\n" +
+            "       child_cons_cols.referenced_table_schema  as ref_table_schema,\n" +
+            "       child_cons_cols.referenced_table_name    as ref_table_name,\n" +
+            "       child_cons_cols.referenced_column_name   as ref_column_name\n" +
+            "  from information_schema.table_constraints as child_constraint\n" +
+            "  join information_schema.key_column_usage as child_cons_cols\n" +
+            "       on (child_constraint.constraint_schema = child_cons_cols.constraint_schema\n" +
+            "           and\n" +
+            "           child_constraint.constraint_name = child_cons_cols.constraint_name\n" +
+            "           and\n" +
+            "           child_constraint.table_schema = child_cons_cols.table_schema\n" +
+            "           and\n" +
+            "           child_constraint.table_name = child_cons_cols.table_name)\n" +
+            "where child_constraint.constraint_type = 'FOREIGN KEY' and child_constraint.table_name=?");
+
+    private final DefaultColumnOrdersFinder defaultColumnOrdersFinder;
+
+    private final NotNullColumnsFinder defaultNotNullColumnsFinder;
+
+    private final PostgreSqlMariaDbReferencedTablesFinder postgreSqlMariaDbReferencedTablesFinder;
+
+    private final BaseColumnsMappingsFinder mariaDbMySqlColumnsMappingsFinder;
+
+    private final PrimaryKeyColumnsFinder primaryKeyColumnsFinder;
+
+    MariaDBMySQLMetadataFinder(DataSource dataSource) {
+        this.defaultColumnOrdersFinder = new DefaultColumnOrdersFinder(dataSource);
+        this.defaultNotNullColumnsFinder = new DefaultNotNullColumnsFinder(dataSource);
+        this.postgreSqlMariaDbReferencedTablesFinder = new PostgreSqlMariaDbReferencedTablesFinder(dataSource);
+        this.mariaDbMySqlColumnsMappingsFinder = new BaseColumnsMappingsFinder(dataSource, MARIA_DB_MY_SQL_COLUMNS_MAPPINGS_QUERY);
+        this.primaryKeyColumnsFinder = new DefaultPrimaryKeyColumnsFinder(dataSource);
+    }
+
+    @Override
+    public List<String> findDatabaseColumnOrdersOf(String tableName) {
+        return defaultColumnOrdersFinder.findDatabaseColumnOrdersOf(tableName);
+    }
+
+    @Override
+    public Collection<String> findNotNullColumnsOf(String tableName) {
+        return defaultNotNullColumnsFinder.findNotNullColumnsOf(tableName);
+    }
+
+    @Override
+    public ReferencedTableSet findReferencedTablesOf(String tableName) {
+        return postgreSqlMariaDbReferencedTablesFinder.findReferencedTablesOf(tableName);
+    }
+
+    @Override
+    public ColumnsMappingGroup findColumnsMappingsOf(String tableName) {
+        return mariaDbMySqlColumnsMappingsFinder.findColumnsMappingsOf(tableName);
+    }
+
+    @Override
+    public List<String> findPrimaryColumnsOf(String tableName) {
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/org/stdg/dbtype/PostgreSqlMariaDbReferencedTablesFinder.java
+++ b/src/main/java/org/stdg/dbtype/PostgreSqlMariaDbReferencedTablesFinder.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2021-2021 the original author or authors.
+ */
+
+package org.stdg.dbtype;
+
+import org.stdg.ReferencedTableSet;
+import org.stdg.ReferencedTablesFinder;
+import org.stdg.SqlQuery;
+
+import javax.sql.DataSource;
+
+class PostgreSqlMariaDbReferencedTablesFinder implements ReferencedTablesFinder {
+
+    private static final SqlQuery REFERENCED_TABLES_QUERY = new SqlQuery("with \n" +
+            "    recursive parent_child_tree as\n" +
+            "    (\n" +
+            "    with parent_child as\n" +
+            "        (\n" +
+            "        select distinct\n" +
+            "            child.table_schema  as table_schema,\n" +
+            "            child.table_name    as table_name,\n" +
+            "            parent.table_schema as ref_table_schema,\n" +
+            "            parent.table_name   as ref_table_name\n" +
+            "        from information_schema.referential_constraints rco\n" +
+            "        join information_schema.table_constraints child\n" +
+            "             on rco.constraint_name = child.constraint_name\n" +
+            "             and rco.constraint_schema = child.table_schema\n" +
+            "        join information_schema.table_constraints parent\n" +
+            "             on rco.unique_constraint_name = parent.constraint_name\n" +
+            "             and rco.unique_constraint_schema = parent.table_schema\n" +
+            "        where child.table_name != parent.table_name\n" +
+            "        )\n" +
+            "    select table_name, ref_table_name, 1 as level\n" +
+            "      from parent_child\n" +
+            "     where table_name=?\n" +
+            "    UNION\n" +
+            "    select pc.table_name, pc.ref_table_name, pct.level + 1 as level\n" +
+            "      from parent_child_tree pct\n" +
+            "      join parent_child pc on (pc.table_name = pct.ref_table_name)\n" +
+            "    )\n" +
+            "select *\n" +
+            "from parent_child_tree\n" +
+            "order by level desc");
+
+    private final BaseReferencedTablesFinder referencedTablesFinder;
+
+    PostgreSqlMariaDbReferencedTablesFinder(DataSource dataSource) {
+        this.referencedTablesFinder = new BaseReferencedTablesFinder(dataSource
+                , REFERENCED_TABLES_QUERY);
+    }
+
+    @Override
+    public ReferencedTableSet findReferencedTablesOf(String tableName) {
+        return referencedTablesFinder.findReferencedTablesOf(tableName);
+    }
+
+}

--- a/src/main/java/org/stdg/dbtype/PostgreSqlMetadataFinder.java
+++ b/src/main/java/org/stdg/dbtype/PostgreSqlMetadataFinder.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2021-2021 the original author or authors.
+ */
+
+package org.stdg.dbtype;
+
+import org.stdg.*;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.List;
+
+class PostgreSqlMetadataFinder implements DatabaseMetadataFinder {
+
+    private static final SqlQuery POSTGRE_SQL_COLUMNS_MAPPINGS_QUERY = new SqlQuery("select\n" +
+            "       tc.table_schema     as table_schema,\n" +
+            "       tc.table_name       as table_name,\n" +
+            "       kcu.column_name     as column_name,\n" +
+            "       ccu.table_schema    as ref_table_schema,\n" +
+            "       ccu.table_name      as ref_table_name,\n" +
+            "       ccu.column_name     as ref_column_name\n" +
+            "  from information_schema.table_constraints as tc\n" +
+            "  join information_schema.key_column_usage as kcu\n" +
+            "       using (constraint_schema, constraint_name, table_schema)\n" +
+            "  join information_schema.constraint_column_usage as ccu\n" +
+            "       using (constraint_schema, constraint_name, table_schema)\n" +
+            "where tc.constraint_type = 'FOREIGN KEY' and tc.table_name=?");
+
+    private final DefaultColumnOrdersFinder defaultColumnOrdersFinder;
+
+    private final NotNullColumnsFinder defaultNotNullColumnsFinder;
+
+    private final PostgreSqlMariaDbReferencedTablesFinder postgreSqlMariaDbReferencedTablesFinder;
+
+    private final ColumnsMappingsFinder postgreSqlColumnsMappingsFinder;
+
+    private final PrimaryKeyColumnsFinder primaryKeyColumnsFinder;
+
+    PostgreSqlMetadataFinder(DataSource dataSource) {
+        this.defaultColumnOrdersFinder = new DefaultColumnOrdersFinder(dataSource);
+        this.defaultNotNullColumnsFinder = new DefaultNotNullColumnsFinder(dataSource);
+        this.postgreSqlMariaDbReferencedTablesFinder = new PostgreSqlMariaDbReferencedTablesFinder(dataSource);
+        this.postgreSqlColumnsMappingsFinder = new BaseColumnsMappingsFinder(dataSource, POSTGRE_SQL_COLUMNS_MAPPINGS_QUERY);
+        this.primaryKeyColumnsFinder = new DefaultPrimaryKeyColumnsFinder(dataSource);
+    }
+
+    @Override
+    public List<String> findDatabaseColumnOrdersOf(String tableName) {
+        return defaultColumnOrdersFinder.findDatabaseColumnOrdersOf(tableName);
+    }
+
+    @Override
+    public Collection<String> findNotNullColumnsOf(String tableName) {
+        return defaultNotNullColumnsFinder.findNotNullColumnsOf(tableName);
+    }
+
+    @Override
+    public ReferencedTableSet findReferencedTablesOf(String tableName) {
+        return postgreSqlMariaDbReferencedTablesFinder.findReferencedTablesOf(tableName);
+    }
+
+    @Override
+    public ColumnsMappingGroup findColumnsMappingsOf(String tableName) {
+        return postgreSqlColumnsMappingsFinder.findColumnsMappingsOf(tableName);
+    }
+
+    @Override
+    public List<String> findPrimaryColumnsOf(String tableName) {
+        return primaryKeyColumnsFinder.findPrimaryColumnsOf(tableName);
+    }
+
+}

--- a/src/test/java/org/stdg/test/FastTestSuite.java
+++ b/src/test/java/org/stdg/test/FastTestSuite.java
@@ -23,6 +23,6 @@ import org.junit.runner.RunWith;
 @SelectClasses( {  H2Test.class
                  , DatasetRowApiTest.class
                  , DatasetRowsMergingTest.class
-                 , JdcRoundtripTest.class} )
+                 , JdbcRoundtripTest.class} )
 public class FastTestSuite {
 }

--- a/src/test/java/org/stdg/test/H2Test.java
+++ b/src/test/java/org/stdg/test/H2Test.java
@@ -21,7 +21,6 @@ import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class H2Test extends H2Configuration {
 

--- a/src/test/java/org/stdg/test/HsqlDbTest.java
+++ b/src/test/java/org/stdg/test/HsqlDbTest.java
@@ -22,7 +22,6 @@ import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class HsqlDbTest {
 

--- a/src/test/java/org/stdg/test/JdbcRoundtripTest.java
+++ b/src/test/java/org/stdg/test/JdbcRoundtripTest.java
@@ -26,7 +26,7 @@ import java.util.Random;
 @Disabled
 @QuickPerfTest
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class JdcRoundtripTest {
+public class JdbcRoundtripTest {
 
     private static DataSource DATA_SOURCE;
 

--- a/src/test/java/org/stdg/test/MSSQLServerTest.java
+++ b/src/test/java/org/stdg/test/MSSQLServerTest.java
@@ -25,7 +25,6 @@ import java.util.Random;
 import static org.stdg.test.TestTable.TestTableAssert.assertThat;
 import static org.stdg.test.TestTable.buildUniqueTable;
 
-@Disabled
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class MSSQLServerTest {
 

--- a/src/test/java/org/stdg/test/MariaDBTest.java
+++ b/src/test/java/org/stdg/test/MariaDBTest.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.stdg.test.TestTable.TestTableAssert.assertThat;
 import static org.stdg.test.TestTable.buildUniqueTable;
 
-@Disabled
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class MariaDBTest {
 

--- a/src/test/java/org/stdg/test/PostgreSqlTest.java
+++ b/src/test/java/org/stdg/test/PostgreSqlTest.java
@@ -23,7 +23,6 @@ import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@Disabled
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class PostgreSqlTest {
 


### PR DESCRIPTION
The *SQL test data generator* features are implemented for the following databases:

* H2
* HSQLDB
* MySQL
* MariaDB
* PostgreSQL
* MS SQL Server