### PR TITLE
Prevent duplicate CI runs on pull requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   linux:


### PR DESCRIPTION
Restrict push trigger to main branch only. Pull requests from branches are covered by the pull_request trigger, so the push trigger was causing redundant duplicate builds.